### PR TITLE
docs: Fix README feature description

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The demo application is available at [GitHub Pages](https://koji-1009.github.io/
 * Set custom headers for GET requests.
 * Check the max age of the data.
 * Set custom cache duration (e.g., 7 days) independent of server headers.
-* Reduce the size of the data by resizing the image.
+* Reduce decoded image memory usage with `cacheWidth` / `cacheHeight`.
 
 ## Usage
 


### PR DESCRIPTION
The image package was removed in 40f603b, so resizing no longer shrinks the data bytes. Update the bullet to reflect what cacheWidth / cacheHeight actually do — reducing decoded image memory via Flutter's ResizeImage.